### PR TITLE
Avoid file duplication

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,6 @@ module.exports = function gulpJavaScriptObfuscator(options) {
 			try {
 				obfuscationResult = JavaScriptObfuscator.obfuscate(String(file.contents), options);
 				file.contents = new Buffer(obfuscationResult.getObfuscatedCode());
-				this.push(file);
 				if(options.sourceMap && options.sourceMapMode !== 'inline') {
 					this.push(new gutil.File({
 						cwd: file.cwd,


### PR DESCRIPTION
Since we pass the file to the callback, firing `this.push` cause
to duplicate the stream. It's unnoticeable when use `gulp.dest`,
but is when use `gulp-concat` for example