### PR TITLE
Use `gulp-sourcemaps` for source maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,51 @@ gulp.src('file.js')
 ```javascript
 gulp.src('file.js')
     .pipe(javascriptObfuscator({
-        compact:true,
-        sourceMap: true
+        compact: true
     }))
     .pipe(gulp.dest('dist'));
 ```
 
-Using **sourceMap** option with value set to **true** will also output a _.map_ file to Gulp stream.
+The only exception is obfuscator's `sourceMap` option which will be handled automatically.
+
+## Source Maps
+
+With version `1.1.6` onwards, gulp-javascript-obfuscator can be used in tandem with [gulp-sourcemaps](https://github.com/floridoo/gulp-sourcemaps) in order to generate source maps for your javascript files.
+
+You will need to initialize gulp-sourcemaps prior to running gulp-javascript-obfuscator and write the source maps after, as such:
+
+```javascript
+const sourcemaps = require('gulp-sourcemaps');
+
+gulp.src('file.js')
+    .pipe(sourcemaps.init())
+    .pipe(javascriptObfuscator({
+        compact: true
+    }))
+    .pipe(sourcemaps.write())
+    .pipe(gulp.dest('dist'));
+```
+
+This will output a `file.js.map` file to the **dist** directory.
+
+You can chain other gulp plugins as well:
+
+```javascript
+const sourcemaps = require('gulp-sourcemaps');
+
+gulp.src('file.js')
+    .pipe(sourcemaps.init())
+    // use babel to pre-process javascript files
+    .pipe(babel({
+        presets: ['@babel/preset-env']
+    }))
+    .pipe(javascriptObfuscator({
+        compact: true
+    }))
+    .pipe(sourcemaps.write())
+    .pipe(gulp.dest('dist'));
+```
+
+### Alternative source maps method
+
+For backwards compatibility, using obfuscator's **sourceMap** option set to **true** will output a _.map_ file to Gulp stream. ([This is _deprecated_ and not recommended for future use.](https://github.com/javascript-obfuscator/gulp-javascript-obfuscator/pull/18))

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ gulp.src('file.js')
     .pipe(gulp.dest('dist'));
 ```
 
-The only exception is obfuscator's `sourceMap` option which will be handled automatically.
+The only exception is obfuscator's `sourceMap` option which must not be set, as it will be handled automatically when using `gulp-sourcemaps`.
 
 ## Source Maps
 
@@ -75,4 +75,4 @@ gulp.src('file.js')
 
 ### Alternative source maps method
 
-For backwards compatibility, using obfuscator's **sourceMap** option set to **true** will output a _.map_ file to Gulp stream. ([This is _deprecated_ and not recommended for future use.](https://github.com/javascript-obfuscator/gulp-javascript-obfuscator/pull/18))
+For backwards compatibility, if `gulp-sourcemaps` is not used and obfuscator's **sourceMap** option is set to **true**, a _.map_ file will be thrown to Gulp stream. ([This method is _deprecated_ and not recommended for future use.](https://github.com/javascript-obfuscator/gulp-javascript-obfuscator/pull/18#backwards-compatibility))

--- a/index.js
+++ b/index.js
@@ -2,22 +2,35 @@ const through2 = require('through2');
 const Vinyl = require('vinyl');
 const JavaScriptObfuscator = require('javascript-obfuscator');
 const PluginError = require('plugin-error');
+const applySourceMap = require('vinyl-sourcemaps-apply');
 
 module.exports = function gulpJavaScriptObfuscator (options = {}) {
 	return through2.obj(function (file, enc, cb) {
 		if (file.isNull()) return cb(null, file);
 		if (!file.isBuffer()) throw new PluginError('gulp-javascript-obfuscator', 'Only Buffers are supported!');
+		if (file.sourceMap) {
+			options.sourceMap = true;
+			options.inputFileName = file.relative;
+			options.sourceMapMode = 'separate';
+		}
 
 		try {
 			const obfuscationResult = JavaScriptObfuscator.obfuscate(String(file.contents), options);
 			file.contents = new Buffer(obfuscationResult.getObfuscatedCode());
 			if (options.sourceMap && options.sourceMapMode !== 'inline') {
-				this.push(new Vinyl({
-					cwd: file.cwd,
-					base: file.base,
-					path: file.path + '.map',
-					contents: new Buffer(obfuscationResult.getSourceMap())
-				}))
+				if ( file.sourceMap ) {
+					const sourceMap = JSON.parse(obfuscationResult.getSourceMap());
+					sourceMap.file = file.sourceMap.file;
+					applySourceMap(file, sourceMap);
+				}
+				else {
+					this.push(new Vinyl({
+						cwd: file.cwd,
+						base: file.base,
+						path: file.path + '.map',
+						contents: new Buffer(obfuscationResult.getSourceMap())
+					}))
+				}
 			}
 			return cb(null, file);
 		} catch (err) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-javascript-obfuscator",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Gulp plugin for javascript-obfuscator Node.JS package",
   "homepage": "https://github.com/javascript-obfuscator/gulp-javascript-obfuscator",
   "repository": {
@@ -27,7 +27,7 @@
   ],
   "author": "Wain-PC",
   "contributors": [
-    "adamxtokyo"
+    "adamxtokyo", "DRSDavidSoft"
   ],
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
### Description
This PR addresses a couple of issues with source maps:
- uses correct file names (fixes #13)
- is chainable with other plugins such as UglifyJS and Babel
- prevents plugins such as `gulp-header` from prepending to the source maps as well as the code

Because of https://github.com/javascript-obfuscator/javascript-obfuscator/issues/276, we can now use [gulp-sourcemaps](https://www.npmjs.com/package/gulp-sourcemaps) instead of throwing the source map to the stream! 😄 

### Backwards compatibility
As before,  if `gulp-sourcemaps` is not used and obfuscator's **sourceMap** option is set to **true**, a _.map_ file will be thrown to Gulp stream.

```javascript
gulp.src('file.js')
    .pipe(javascriptObfuscator({
        compact: true,
        sourceMap: true
    }))
    .pipe(gulp.dest('dist'));
```

_NOTE:_ The old method is not recommended for new projects, for the following reasons:

1. Any gulp plugin that is chained after gulp-javascript-obfuscator (e.g. `gulp-header` to prepend a banner to the output file) will be applied on _both_ the obfuscated _.js_ file and its _.map_ file.

2. You will not be able to chain any other plugins to the task without loosing its own sourcemap file.