### PR TITLE
Breaking changes: remove deprecated sourcemap generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,51 @@ gulp.src('file.js')
 ```javascript
 gulp.src('file.js')
     .pipe(javascriptObfuscator({
-        compact:true,
-        sourceMap: true
+        compact: true
     }))
     .pipe(gulp.dest('dist'));
 ```
 
-Using **sourceMap** option with value set to **true** will also output a _.map_ file to Gulp stream.
+The only exception is obfuscator's `sourceMap` option which will be handled automatically.
+
+## Source Maps
+
+With version `1.1.6` onwards, gulp-javascript-obfuscator can be used in tandem with [gulp-sourcemaps](https://github.com/floridoo/gulp-sourcemaps) in order to generate source maps for your javascript files.
+
+You will need to initialize gulp-sourcemaps prior to running gulp-javascript-obfuscator and write the source maps after, as such:
+
+```javascript
+const sourcemaps = require('gulp-sourcemaps');
+
+gulp.src('file.js')
+    .pipe(sourcemaps.init())
+    .pipe(javascriptObfuscator({
+        compact: true
+    }))
+    .pipe(sourcemaps.write())
+    .pipe(gulp.dest('dist'));
+```
+
+This will output a `file.js.map` file to the **dist** directory.
+
+You can chain other gulp plugins as well:
+
+```javascript
+const sourcemaps = require('gulp-sourcemaps');
+
+gulp.src('file.js')
+    .pipe(sourcemaps.init())
+    // use babel to pre-process javascript files
+    .pipe(babel({
+        presets: ['@babel/preset-env']
+    }))
+    .pipe(javascriptObfuscator({
+        compact: true
+    }))
+    .pipe(sourcemaps.write())
+    .pipe(gulp.dest('dist'));
+```
+
+### Alternative source maps method
+
+For backwards compatibility, using obfuscator's **sourceMap** option set to **true** will output a _.map_ file to Gulp stream. ([This is _deprecated_ and not recommended for future use.](https://github.com/javascript-obfuscator/gulp-javascript-obfuscator/pull/18))

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The only exception is obfuscator's `sourceMap` option which must not be set, as 
 
 ## Source Maps
 
-With version `1.1.6` onwards, gulp-javascript-obfuscator can be used in tandem with [gulp-sourcemaps](https://github.com/floridoo/gulp-sourcemaps) in order to generate source maps for your javascript files.
+`gulp-javascript-obfuscator` can be used in tandem with [gulp-sourcemaps](https://github.com/floridoo/gulp-sourcemaps) in order to generate source maps for your javascript files.
 
 You will need to initialize gulp-sourcemaps prior to running gulp-javascript-obfuscator and write the source maps after, as such:
 
@@ -73,6 +73,3 @@ gulp.src('file.js')
     .pipe(gulp.dest('dist'));
 ```
 
-### Alternative source maps method
-
-For backwards compatibility, if `gulp-sourcemaps` is not used and obfuscator's **sourceMap** option is set to **true**, a _.map_ file will be thrown to Gulp stream. ([This method is _deprecated_ and not recommended for future use.](https://github.com/javascript-obfuscator/gulp-javascript-obfuscator/pull/18#backwards-compatibility))

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ gulp.src('file.js')
     .pipe(gulp.dest('dist'));
 ```
 
-The only exception is obfuscator's `sourceMap` option which will be handled automatically.
+The only exception is obfuscator's `sourceMap` option which must not be set, as it will be handled automatically when using `gulp-sourcemaps`.
 
 ## Source Maps
 
@@ -75,4 +75,4 @@ gulp.src('file.js')
 
 ### Alternative source maps method
 
-For backwards compatibility, using obfuscator's **sourceMap** option set to **true** will output a _.map_ file to Gulp stream. ([This is _deprecated_ and not recommended for future use.](https://github.com/javascript-obfuscator/gulp-javascript-obfuscator/pull/18))
+For backwards compatibility, if `gulp-sourcemaps` is not used and obfuscator's **sourceMap** option is set to **true**, a _.map_ file will be thrown to Gulp stream. ([This method is _deprecated_ and not recommended for future use.](https://github.com/javascript-obfuscator/gulp-javascript-obfuscator/pull/18#backwards-compatibility))

--- a/index.js
+++ b/index.js
@@ -17,20 +17,10 @@ module.exports = function gulpJavaScriptObfuscator (options = {}) {
 		try {
 			const obfuscationResult = JavaScriptObfuscator.obfuscate(String(file.contents), options);
 			file.contents = new Buffer(obfuscationResult.getObfuscatedCode());
-			if (options.sourceMap && options.sourceMapMode !== 'inline') {
-				if ( file.sourceMap ) {
-					const sourceMap = JSON.parse(obfuscationResult.getSourceMap());
-					sourceMap.file = file.sourceMap.file;
-					applySourceMap(file, sourceMap);
-				}
-				else {
-					this.push(new Vinyl({
-						cwd: file.cwd,
-						base: file.base,
-						path: file.path + '.map',
-						contents: new Buffer(obfuscationResult.getSourceMap())
-					}))
-				}
+			if (file.sourceMap) {
+				const sourceMap = JSON.parse(obfuscationResult.getSourceMap());
+				sourceMap.file = file.sourceMap.file;
+				applySourceMap(file, sourceMap);
 			}
 			return cb(null, file);
 		} catch (err) {

--- a/index.js
+++ b/index.js
@@ -2,22 +2,35 @@ const through2 = require('through2');
 const Vinyl = require('vinyl');
 const JavaScriptObfuscator = require('javascript-obfuscator');
 const PluginError = require('plugin-error');
+const applySourceMap = require('vinyl-sourcemaps-apply');
 
 module.exports = function gulpJavaScriptObfuscator (options = {}) {
 	return through2.obj(function (file, enc, cb) {
 		if (file.isNull()) return cb(null, file);
 		if (!file.isBuffer()) throw new PluginError('gulp-javascript-obfuscator', 'Only Buffers are supported!');
+		if (file.sourceMap) {
+			options.sourceMap = true;
+			options.inputFileName = file.relative;
+			options.sourceMapMode = 'separate';
+		}
 
 		try {
 			const obfuscationResult = JavaScriptObfuscator.obfuscate(String(file.contents), options);
 			file.contents = new Buffer(obfuscationResult.getObfuscatedCode());
 			if (options.sourceMap && options.sourceMapMode !== 'inline') {
-				this.push(new Vinyl({
-					cwd: file.cwd,
-					base: file.base,
-					path: file.path + '.map',
-					contents: new Buffer(obfuscationResult.getSourceMap())
-				}))
+				if ( file.sourceMap ) {
+					const sourceMap = JSON.parse(obfuscationResult.getSourceMap());
+					sourceMap.file = file.sourceMap.file;
+					applySourceMap(file, sourceMap);
+				}
+				else {
+					this.push(new Vinyl({
+						cwd: file.cwd,
+						base: file.base,
+						path: file.path + '.map',
+						contents: new Buffer(obfuscationResult.getSourceMap())
+					}))
+				}
 			}
 			return cb(null, file);
 		} catch (err) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-javascript-obfuscator",
-  "version": "1.1.6",
+  "version": "2.0.0",
   "description": "Gulp plugin for javascript-obfuscator Node.JS package",
   "homepage": "https://github.com/javascript-obfuscator/gulp-javascript-obfuscator",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-javascript-obfuscator",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Gulp plugin for javascript-obfuscator Node.JS package",
   "homepage": "https://github.com/javascript-obfuscator/gulp-javascript-obfuscator",
   "repository": {
@@ -27,7 +27,7 @@
   ],
   "author": "Wain-PC",
   "contributors": [
-    "adamxtokyo"
+    "adamxtokyo", "DRSDavidSoft"
   ],
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
### Remove deprecated methods
In previous versions, if `gulp-sourcemaps` was not used and obfuscator's **sourceMap** option was set to **true**, a _.map_ file will be thrown to Gulp stream. ([This method is _removed_ in this PR and not recommended for future use.](https://github.com/javascript-obfuscator/gulp-javascript-obfuscator/pull/18#backwards-compatibility))

This PR is intended to be merged in the next release (`2.0.0`)
